### PR TITLE
feat: add admin vs user role-based access

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,18 +2,18 @@
 
 ## Project Overview
 
-A Vite + React single-page blog editor backed by Supabase for auth and data storage. The app uses hash-based routing so it can still be deployed statically while keeping the editor behind authenticated routes.
+A Vite + React single-page blog editor backed by Supabase for auth and data storage. The app uses hash-based routing so it can still be deployed statically. Role-based access (admin vs user) controls who can create, edit, and delete entries — regular users can only read and comment.
 
 ## Key Files
 
 - `src/main.jsx` — React mount point with `HashRouter` and `AuthProvider`
 - `src/app.jsx` — Route tree with lazy-loaded pages
 - `src/components/layout.jsx` — Shared shell and navigation
-- `src/components/protected-route.jsx` — Auth gate for editor routes
+- `src/components/protected-route.jsx` — ProtectedRoute (auth gate) and AdminRoute (admin gate)
 - `src/components/tiptap-editor.jsx` — Tiptap editor wrapper
 - `src/pages/` — Login, entries, view, and editor pages
 - `src/contexts/auth-context.jsx` — Supabase auth state and auth actions
-- `src/hooks/use-entries.js` — Entry fetch/create/update logic
+- `src/hooks/use-entries.js` — Entry fetch/create/update/delete logic
 - `src/lib/supabase.js` — Supabase client init
 - `supabase/migrations/` — Database schema migrations
 
@@ -48,9 +48,11 @@ After making any code change, check whether README.md and/or USAGE.md need updat
 
 - Project URL: `https://zmplxklzsjkuipttflnd.supabase.co`
 - Migrations are managed via the Supabase CLI (`npx supabase migration new`, `npx supabase db push`)
-- RLS is enabled — all table policies restrict access to the authenticated user's own rows
+- RLS is enabled — entry writes restricted to admin role via `is_admin()` function; comments restricted to own rows
+- Roles are stored in `user_roles` table — manage via Supabase dashboard SQL editor
 
 ## Projects and Tasks
 
 - React migration to Vite/React/shadcn/ui/Tiptap completed on 2026-03-27
+- Admin vs user role-based access implemented on 2026-03-29 (issue #1)
 - Keep future work aligned with the React architecture and avoid reintroducing vanilla app files

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Blog Editor
 
-A lightweight React blog editor backed by Supabase for authentication and entry storage. The app uses hash-based routing so it can still be deployed as a static site, while protected editor routes keep creation and updates behind login.
+A lightweight React blog editor backed by Supabase for authentication and entry storage. The app uses hash-based routing so it can still be deployed as a static site. Role-based access control separates admin capabilities (create, edit, delete entries and manage profile) from regular user capabilities (read entries and comment).
 
 ## Tech Stack
 
@@ -17,7 +17,7 @@ src/main.jsx                   React mount point with HashRouter + AuthProvider
 src/app.jsx                    Route tree with lazy-loaded pages
 src/components/layout.jsx      Shared shell with session bar and navigation
 src/components/protected-route.jsx
-                               Redirects unauthenticated users to /login
+                               ProtectedRoute (auth gate) and AdminRoute (admin gate)
 src/components/tiptap-editor.jsx
                                Rich text editor wrapper and toolbar
 src/pages/login-page.jsx       Login and sign-up flow
@@ -39,19 +39,31 @@ The app uses `HashRouter`, which keeps static hosting simple while still support
 | `#/login` | Email/password login or sign-up |
 | `#/entries` | Public entries list |
 | `#/view/:entryId` | Public read-only entry page |
-| `#/editor` | Protected page for creating a new entry |
-| `#/editor/:entryId` | Protected page for editing an existing entry |
+| `#/editor` | Admin-only page for creating a new entry |
+| `#/editor/:entryId` | Admin-only page for editing an existing entry |
+| `#/profile` | Admin-only profile management page |
+
+## Roles
+
+| Role | Capabilities |
+|------|-------------|
+| **Admin** | Create, edit, delete entries; manage profile; comment |
+| **User** | Read entries; comment |
+| **Visitor** (unauthenticated) | Read entries |
+
+Roles are stored in the `user_roles` table. An `is_admin()` SQL function is used in RLS policies to restrict entry writes to admins.
 
 ## Entry Behavior
 
 - Visitors can browse the entries list and open an entry view
-- Signed-in owners see edit actions for their own entries
+- Admin users see edit/delete actions on entries and can create new ones
+- Regular users can read entries and comment, but cannot create or modify entries
 - Rich text content is stored as HTML and rendered directly on the view page
 - New entries and updates redirect back to the entries list after save
 
 ## Database Schema
 
-The existing Supabase schema is unchanged. The key table is still `entries`:
+### entries
 
 | Column | Type | Description |
 |--------|------|-------------|
@@ -60,6 +72,15 @@ The existing Supabase schema is unchanged. The key table is still `entries`:
 | `title` | text | Entry title |
 | `content` | text | Entry body stored as HTML |
 | `published_at` | date | Publication date |
+| `created_at` | timestamptz | Row creation timestamp |
+
+### user_roles
+
+| Column | Type | Description |
+|--------|------|-------------|
+| `id` | uuid | Primary key (auto-generated) |
+| `user_id` | uuid | Foreign key to `auth.users` (unique) |
+| `role` | text | Either `'admin'` or `'user'` |
 | `created_at` | timestamptz | Row creation timestamp |
 
 ## Setup

--- a/USAGE.md
+++ b/USAGE.md
@@ -10,13 +10,24 @@
 4. Check your email for a confirmation link
 5. After confirming, log in with your credentials
 
+New accounts are created with the **user** role by default. Only the site owner has the **admin** role.
+
 ### Log In / Log Out
 
 - Enter your email and password on the login screen and click **Log in**
 - Your session persists across page refreshes
 - Click **Log out** in the top-right corner to end your session
 
-## Writing an Entry
+## Roles
+
+There are two roles in the app:
+
+- **Admin** (site owner): Can create, edit, and delete blog entries, manage their profile, and comment on entries
+- **User** (registered visitor): Can read entries and comment on them
+
+The Editor and Profile tabs in the navigation bar are only visible to admins.
+
+## Writing an Entry (Admin Only)
 
 1. Navigate to the **Editor** tab
 2. Type a title in the title field at the top
@@ -37,22 +48,38 @@ After publishing, you're automatically taken to the entries list.
 2. Each entry shows its publication date and title
 3. Click **View entry** to read the full entry
 
-## Editing an Entry
+All entries are publicly readable — no login required.
+
+## Editing an Entry (Admin Only)
 
 1. Navigate to the **Entries** tab
-2. Log in if you are not already signed in
-3. Click **Edit** on an entry you own
+2. Click **Edit** on the entry you want to change
 3. The editor loads with the existing title and content
 4. Make your changes — the button will show **Update** instead of Publish
 5. Click **Update** to save
 
 The original publication date is preserved when you edit.
 
+## Deleting an Entry (Admin Only)
+
+1. Navigate to the **Entries** tab
+2. Click **Delete** on the entry you want to remove
+3. The entry is permanently removed and the list refreshes
+
+## Commenting
+
+1. Open any entry by clicking **View entry**
+2. Scroll to the comments section at the bottom
+3. Log in if you are not already signed in
+4. Type your comment and click **Post**
+
+Both admins and regular users can comment. You can delete your own comments.
+
 ## Things to Know
 
-- The entries list and entry view are publicly readable in the app
-- Only authenticated users can open the editor
-- You can only edit entries you own
+- The entries list and entry view are publicly readable
+- Only admins can create, edit, or delete entries
+- Any authenticated user can comment on entries
 - Content is stored as rich text (HTML), so formatting is preserved
 - Entries are listed newest-first
 - An entry without a title will display as "Untitled" in the list

--- a/src/app.jsx
+++ b/src/app.jsx
@@ -2,7 +2,7 @@ import { lazy, Suspense } from "react";
 import { Navigate, Route, Routes } from "react-router-dom";
 import { Card, CardContent } from "@/components/ui/card";
 import { Layout } from "@/components/layout";
-import { ProtectedRoute } from "@/components/protected-route";
+import { AdminRoute } from "@/components/protected-route";
 
 const EditorPage = lazy(() =>
   import("@/pages/editor-page").then((module) => ({
@@ -49,7 +49,7 @@ export default function App() {
           <Route path="/login" element={<LoginPage />} />
           <Route path="/entries" element={<EntriesPage />} />
           <Route path="/view/:entryId" element={<ViewPage />} />
-          <Route element={<ProtectedRoute />}>
+          <Route element={<AdminRoute />}>
             <Route path="/editor" element={<EditorPage />} />
             <Route path="/editor/:entryId" element={<EditorPage />} />
             <Route path="/profile" element={<ProfilePage />} />

--- a/src/components/layout.jsx
+++ b/src/components/layout.jsx
@@ -14,7 +14,7 @@ const navLinkClassName = ({ isActive }) =>
 
 export function Layout() {
   const navigate = useNavigate();
-  const { user, signOut } = useAuth();
+  const { user, isAdmin, signOut } = useAuth();
 
   const handleLogout = async () => {
     await signOut();
@@ -78,7 +78,7 @@ export function Layout() {
                 Entries
               </NavLink>
 
-              {user ? (
+              {isAdmin ? (
                 <>
                   <NavLink className={navLinkClassName} to="/editor">
                     <PenSquare className="mr-2 size-4" />

--- a/src/components/protected-route.jsx
+++ b/src/components/protected-route.jsx
@@ -2,6 +2,10 @@ import { Navigate, Outlet, useLocation } from "react-router-dom";
 import { Card, CardContent } from "@/components/ui/card";
 import { useAuth } from "@/contexts/auth-context";
 
+/**
+ * Gates routes that require any authenticated user.
+ * Redirects unauthenticated visitors to /login.
+ */
 export function ProtectedRoute() {
   const location = useLocation();
   const { user, loading } = useAuth();
@@ -18,6 +22,36 @@ export function ProtectedRoute() {
 
   if (!user) {
     return <Navigate replace state={{ from: location }} to="/login" />;
+  }
+
+  return <Outlet />;
+}
+
+/**
+ * Gates routes that require the admin role.
+ * - Unauthenticated visitors -> /login
+ * - Authenticated non-admins -> /entries (they're logged in, just not authorized)
+ */
+export function AdminRoute() {
+  const location = useLocation();
+  const { user, isAdmin, loading } = useAuth();
+
+  if (loading) {
+    return (
+      <Card className="mx-auto max-w-xl border-border/70 bg-background/90 shadow-lg shadow-black/5">
+        <CardContent className="px-6 py-14 text-center text-sm text-muted-foreground">
+          Restoring your session...
+        </CardContent>
+      </Card>
+    );
+  }
+
+  if (!user) {
+    return <Navigate replace state={{ from: location }} to="/login" />;
+  }
+
+  if (!isAdmin) {
+    return <Navigate replace to="/entries" />;
   }
 
   return <Outlet />;

--- a/src/contexts/auth-context.jsx
+++ b/src/contexts/auth-context.jsx
@@ -3,19 +3,56 @@ import { supabase } from "@/lib/supabase";
 
 const AuthContext = createContext(null);
 
+/**
+ * Query the user_roles table to check if the given user is an admin.
+ * Returns true only when a row exists with role = 'admin'.
+ * RLS ensures users can only read their own role.
+ */
+const fetchIsAdmin = async (userId) => {
+  const { data } = await supabase
+    .from("user_roles")
+    .select("role")
+    .eq("user_id", userId)
+    .single();
+
+  return data?.role === "admin";
+};
+
 export function AuthProvider({ children }) {
   const [user, setUser] = useState(null);
+  const [isAdmin, setIsAdmin] = useState(false);
   const [loading, setLoading] = useState(true);
 
   useEffect(() => {
-    supabase.auth.getSession().then(({ data: { session } }) => {
-      setUser(session?.user ?? null);
+    // Restore existing session on mount
+    supabase.auth.getSession().then(async ({ data: { session } }) => {
+      const currentUser = session?.user ?? null;
+      setUser(currentUser);
+
+      // Fetch role before clearing loading so downstream components
+      // have isAdmin available on first render
+      if (currentUser) {
+        const admin = await fetchIsAdmin(currentUser.id);
+        setIsAdmin(admin);
+      } else {
+        setIsAdmin(false);
+      }
+
       setLoading(false);
     });
 
+    // Listen for auth state changes (login, logout, token refresh)
     const { data: { subscription } } = supabase.auth.onAuthStateChange(
-      (_event, session) => {
-        setUser(session?.user ?? null);
+      async (_event, session) => {
+        const currentUser = session?.user ?? null;
+        setUser(currentUser);
+
+        if (currentUser) {
+          const admin = await fetchIsAdmin(currentUser.id);
+          setIsAdmin(admin);
+        } else {
+          setIsAdmin(false);
+        }
       }
     );
 
@@ -37,7 +74,7 @@ export function AuthProvider({ children }) {
   };
 
   return (
-    <AuthContext.Provider value={{ user, loading, signIn, signUp, signOut }}>
+    <AuthContext.Provider value={{ user, isAdmin, loading, signIn, signUp, signOut }}>
       {children}
     </AuthContext.Provider>
   );

--- a/src/hooks/use-entries.js
+++ b/src/hooks/use-entries.js
@@ -57,3 +57,13 @@ export async function updateEntry(id, { title, content }) {
 
   return { error };
 }
+
+/* Delete an entry by ID (admin-only — enforced by RLS) */
+export async function deleteEntry(id) {
+  const { error } = await supabase
+    .from("entries")
+    .delete()
+    .eq("id", id);
+
+  return { error };
+}

--- a/src/pages/entries-page.jsx
+++ b/src/pages/entries-page.jsx
@@ -4,7 +4,7 @@ import { ArrowRight, PencilLine, RefreshCw } from "lucide-react";
 import { Button, buttonVariants } from "@/components/ui/button";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 import { useAuth } from "@/contexts/auth-context";
-import { useEntries } from "@/hooks/use-entries";
+import { useEntries, deleteEntry } from "@/hooks/use-entries";
 import { cn } from "@/lib/utils";
 
 const formatPublishedDate = (publishedAt) => {
@@ -20,7 +20,7 @@ const formatPublishedDate = (publishedAt) => {
 };
 
 export function EntriesPage() {
-  const { user } = useAuth();
+  const { user, isAdmin } = useAuth();
   const { entries, loading, error, fetchEntries } = useEntries();
 
   useEffect(() => {
@@ -35,8 +35,8 @@ export function EntriesPage() {
             Latest entries
           </CardTitle>
           <CardDescription className="max-w-2xl text-sm leading-6">
-            Browse everything in the blog. Signed-in owners can jump directly
-            into editing from here.
+            Browse everything in the blog. Admins can edit and manage entries
+            from here.
           </CardDescription>
         </div>
 
@@ -51,19 +51,12 @@ export function EntriesPage() {
             Refresh
           </Button>
 
-          {user ? (
+          {isAdmin ? (
             <Link className={cn(buttonVariants())} to="/editor">
               <PencilLine className="mr-2 size-4" />
               New entry
             </Link>
-          ) : (
-            <Link
-              className={cn(buttonVariants({ variant: "secondary" }))}
-              to="/login"
-            >
-              Log in to write
-            </Link>
-          )}
+          ) : null}
         </div>
       </CardHeader>
 
@@ -88,44 +81,53 @@ export function EntriesPage() {
 
         {!loading && !error && entries.length > 0 ? (
           <div className="space-y-3">
-            {entries.map((entry) => {
-              const isOwner = user?.id === entry.user_id;
+            {entries.map((entry) => (
+              <article
+                className="flex flex-col gap-4 border border-border/70 bg-muted/30 p-5 transition-transform hover:-translate-y-0.5 hover:bg-muted/45 sm:flex-row sm:items-center sm:justify-between"
+                key={entry.id}
+              >
+                <div className="space-y-2">
+                  <p className="text-xs font-semibold uppercase tracking-[0.22em] text-muted-foreground">
+                    {formatPublishedDate(entry.published_at)}
+                  </p>
+                  <h3 className="text-lg font-semibold text-foreground">
+                    {entry.title || "Untitled"}
+                  </h3>
+                </div>
 
-              return (
-                <article
-                  className="flex flex-col gap-4 border border-border/70 bg-muted/30 p-5 transition-transform hover:-translate-y-0.5 hover:bg-muted/45 sm:flex-row sm:items-center sm:justify-between"
-                  key={entry.id}
-                >
-                  <div className="space-y-2">
-                    <p className="text-xs font-semibold uppercase tracking-[0.22em] text-muted-foreground">
-                      {formatPublishedDate(entry.published_at)}
-                    </p>
-                    <h3 className="text-lg font-semibold text-foreground">
-                      {entry.title || "Untitled"}
-                    </h3>
-                  </div>
-
-                  <div className="flex flex-wrap gap-3">
-                    {isOwner ? (
+                <div className="flex flex-wrap gap-3">
+                  {isAdmin ? (
+                    <>
                       <Link
                         className={cn(buttonVariants({ variant: "outline" }))}
                         to={`/editor/${entry.id}`}
                       >
                         Edit
                       </Link>
-                    ) : null}
+                      <Button
+                        onClick={async () => {
+                          const { error } = await deleteEntry(entry.id);
+                          if (!error) {
+                            void fetchEntries();
+                          }
+                        }}
+                        variant="outline"
+                      >
+                        Delete
+                      </Button>
+                    </>
+                  ) : null}
 
-                    <Link
-                      className={cn(buttonVariants())}
-                      to={`/view/${entry.id}`}
-                    >
-                      View entry
-                      <ArrowRight className="ml-2 size-4" />
-                    </Link>
-                  </div>
-                </article>
-              );
-            })}
+                  <Link
+                    className={cn(buttonVariants())}
+                    to={`/view/${entry.id}`}
+                  >
+                    View entry
+                    <ArrowRight className="ml-2 size-4" />
+                  </Link>
+                </div>
+              </article>
+            ))}
           </div>
         ) : null}
       </CardContent>

--- a/supabase/migrations/20260329010749_add_user_roles.sql
+++ b/supabase/migrations/20260329010749_add_user_roles.sql
@@ -1,0 +1,62 @@
+-- ============================================================
+-- Migration: add_user_roles
+-- Purpose: Introduce admin vs user role-based access (issue #1)
+-- ============================================================
+
+-- 1. Create user_roles table
+-- Each authenticated user gets one role: 'admin' or 'user'.
+-- Only admins (site owner) can create/edit/delete entries.
+-- Regular users can only comment.
+create table user_roles (
+  id uuid default gen_random_uuid() primary key,
+  user_id uuid references auth.users(id) on delete cascade not null unique,
+  role text not null default 'user' check (role in ('admin', 'user')),
+  created_at timestamptz default now()
+);
+
+alter table user_roles enable row level security;
+
+-- Users can read their own role (needed by frontend auth context)
+create policy "Users can read own role"
+  on user_roles for select
+  using (auth.uid() = user_id);
+
+-- 2. Create is_admin() helper function
+-- Used in RLS policies on other tables to check admin status.
+-- security definer: bypasses RLS on user_roles to avoid circular deps.
+-- stable: result doesn't change within a single SQL statement.
+create or replace function is_admin()
+returns boolean
+language sql
+security definer
+stable
+as $$
+  select exists (
+    select 1
+    from user_roles
+    where user_id = auth.uid()
+      and role = 'admin'
+  );
+$$;
+
+-- 3. Update entries RLS policies
+-- Drop old owner-based write policies and replace with admin-only.
+-- The "Public can read all entries" SELECT policy remains untouched.
+drop policy "Users can read own entries" on entries;
+drop policy "Users can insert own entries" on entries;
+drop policy "Users can update own entries" on entries;
+
+-- Only admins can create entries
+create policy "Admins can insert entries"
+  on entries for insert
+  with check (is_admin());
+
+-- Only admins can edit entries
+create policy "Admins can update entries"
+  on entries for update
+  using (is_admin());
+
+-- Only admins can delete entries (new — no delete policy existed before)
+create policy "Admins can delete entries"
+  on entries for delete
+  using (is_admin());


### PR DESCRIPTION
## Summary

- Adds `user_roles` table and `is_admin()` SQL function for role-based access control
- Admin can create, edit, delete entries and access profile; regular users can only read and comment
- Updates RLS policies on `entries` to restrict writes to admin role
- Adds `AdminRoute` component and `deleteEntry` function

Closes #1

## Test plan

- [ ] Run `npx supabase db push` — migration applies cleanly
- [ ] Seed admin role: `INSERT INTO user_roles (user_id, role) VALUES ('<uuid>', 'admin')`
- [ ] **Admin flow**: Editor/Profile nav visible, can CRUD entries, can comment
- [ ] **User flow**: Editor/Profile nav hidden, `/#/editor` redirects to entries, no Edit/Delete buttons, can comment
- [ ] **Unauthed flow**: entries readable, `/#/editor` redirects to login

🤖 Generated with [Claude Code](https://claude.com/claude-code)